### PR TITLE
Allow ESRGAN models to run with 1x and 8x scale

### DIFF
--- a/src/visp/arch/esrgan.cpp
+++ b/src/visp/arch/esrgan.cpp
@@ -86,7 +86,7 @@ esrgan_params esrgan_detect_params(model_file const& f) {
     p.scale = f.get_int("esrgan.scale");
     p.n_blocks = f.get_int("esrgan.block_count");
     
-    if (p.scale < 2 || p.scale > 4) {
+    if (p.scale < 1 || p.scale > 8) {
         throw except("ESRGAN: unsupported scale: {}", p.scale);
     }
     if (p.n_blocks < 1 || p.n_blocks > 23) {


### PR DESCRIPTION
This PR allows running ESRGAN models with 1x and 8x scale.

For example [1x-NMKD-Jaywreck3-Lite](https://openmodeldb.info/models/1x-NMKD-Jaywreck3-Lite) and [8x_NMKD-Superscale_150000_G](https://civitai.com/models/292030/8xnmkd-superscale150000g).

Both models run after this change, and results for the 1x model are promising.